### PR TITLE
Allow internally mutable executor & reorg libraries

### DIFF
--- a/.solhint.json
+++ b/.solhint.json
@@ -3,7 +3,7 @@
   "plugins": ["prettier"],
   "rules": {
     "avoid-low-level-calls": "off",
-    "compiler-version": ["error", "0.8.18"],
+    "compiler-version": ["error", "0.8.19"],
     "func-visibility": "off",
     "no-empty-blocks": "off",
     "no-inline-assembly": "off"

--- a/src/abstract/ExecutorAware.sol
+++ b/src/abstract/ExecutorAware.sol
@@ -14,6 +14,13 @@ error ExecutorZeroAddress();
  *      to ensure that messages are sent by a trusted `MessageExecutor` contract.
  */
 abstract contract ExecutorAware {
+  /* ============ Events ============ */
+
+  /// @notice Emitted when a new trusted executor is set.
+  /// @param prevExecutor The previous trusted executor address
+  /// @param newExecutor The new trusted executor address
+  event SetTrustedExecutor(address indexed prevExecutor, address indexed newExecutor);
+
   /* ============ Variables ============ */
 
   /// @notice Address of the trusted executor contract.
@@ -55,6 +62,7 @@ abstract contract ExecutorAware {
    */
   function _setTrustedExecutor(address _executor) internal {
     if (address(0) == _executor) revert ExecutorZeroAddress();
+    emit SetTrustedExecutor(_trustedExecutor, _executor);
     _trustedExecutor = _executor;
   }
 

--- a/src/abstract/ExecutorAware.sol
+++ b/src/abstract/ExecutorAware.sol
@@ -17,9 +17,9 @@ abstract contract ExecutorAware {
   /* ============ Events ============ */
 
   /// @notice Emitted when a new trusted executor is set.
-  /// @param prevExecutor The previous trusted executor address
+  /// @param previousExecutor The previous trusted executor address
   /// @param newExecutor The new trusted executor address
-  event SetTrustedExecutor(address indexed prevExecutor, address indexed newExecutor);
+  event SetTrustedExecutor(address indexed previousExecutor, address indexed newExecutor);
 
   /* ============ Variables ============ */
 

--- a/src/abstract/ExecutorAware.sol
+++ b/src/abstract/ExecutorAware.sol
@@ -1,6 +1,8 @@
-// SPDX-License-Identifier: GPL-3.0
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
 
-pragma solidity ^0.8.16;
+/// @notice Thrown if the executor is set to the zero address.
+error ExecutorZeroAddress();
 
 /**
  * @title ExecutorAware abstract contract
@@ -15,7 +17,7 @@ abstract contract ExecutorAware {
   /* ============ Variables ============ */
 
   /// @notice Address of the trusted executor contract.
-  address public immutable trustedExecutor;
+  address private _trustedExecutor;
 
   /* ============ Constructor ============ */
 
@@ -24,21 +26,37 @@ abstract contract ExecutorAware {
    * @param _executor Address of the `MessageExecutor` contract
    */
   constructor(address _executor) {
-    require(_executor != address(0), "executor-not-zero-address");
-    trustedExecutor = _executor;
+    _setTrustedExecutor(_executor);
   }
 
-  /* ============ External Functions ============ */
+  /* ============ Public Functions ============ */
 
   /**
    * @notice Check which executor this contract trust.
    * @param _executor Address to check
    */
   function isTrustedExecutor(address _executor) public view returns (bool) {
-    return _executor == trustedExecutor;
+    return _executor == _trustedExecutor;
+  }
+
+  /**
+   * @notice Getter for the internal trusted executor.
+   * @return The trusted executor address
+   */
+  function trustedExecutor() public view returns (address) {
+    return _trustedExecutor;
   }
 
   /* ============ Internal Functions ============ */
+
+  /**
+   * @notice Sets a new trusted executor.
+   * @param _executor The new address to trust as the executor
+   */
+  function _setTrustedExecutor(address _executor) internal {
+    if (address(0) == _executor) revert ExecutorZeroAddress();
+    _trustedExecutor = _executor;
+  }
 
   /**
    * @notice Retrieve messageId from message data.

--- a/src/abstract/ExecutorAware.sol
+++ b/src/abstract/ExecutorAware.sol
@@ -66,45 +66,4 @@ abstract contract ExecutorAware {
     _trustedExecutor = _executor;
   }
 
-  /**
-   * @notice Retrieve messageId from message data.
-   * @return _msgDataMessageId ID uniquely identifying the message that was executed
-   */
-  function _messageId() internal pure returns (bytes32 _msgDataMessageId) {
-    _msgDataMessageId;
-
-    if (msg.data.length >= 84) {
-      assembly {
-        _msgDataMessageId := calldataload(sub(calldatasize(), 84))
-      }
-    }
-  }
-
-  /**
-   * @notice Retrieve fromChainId from message data.
-   * @return _msgDataFromChainId ID of the chain that dispatched the messages
-   */
-  function _fromChainId() internal pure returns (uint256 _msgDataFromChainId) {
-    _msgDataFromChainId;
-
-    if (msg.data.length >= 52) {
-      assembly {
-        _msgDataFromChainId := calldataload(sub(calldatasize(), 52))
-      }
-    }
-  }
-
-  /**
-   * @notice Retrieve signer address from message data.
-   * @return _signer Address of the signer
-   */
-  function _msgSender() internal view returns (address payable _signer) {
-    _signer = payable(msg.sender);
-
-    if (msg.data.length >= 20 && isTrustedExecutor(_signer)) {
-      assembly {
-        _signer := shr(96, calldataload(sub(calldatasize(), 20)))
-      }
-    }
-  }
 }

--- a/src/abstract/ExecutorAware.sol
+++ b/src/abstract/ExecutorAware.sol
@@ -24,7 +24,7 @@ abstract contract ExecutorAware {
   /* ============ Variables ============ */
 
   /// @notice Address of the trusted executor contract.
-  address private _trustedExecutor;
+  address public trustedExecutor;
 
   /* ============ Constructor ============ */
 
@@ -43,15 +43,7 @@ abstract contract ExecutorAware {
    * @param _executor Address to check
    */
   function isTrustedExecutor(address _executor) public view returns (bool) {
-    return _executor == _trustedExecutor;
-  }
-
-  /**
-   * @notice Getter for the internal trusted executor.
-   * @return The trusted executor address
-   */
-  function trustedExecutor() public view returns (address) {
-    return _trustedExecutor;
+    return _executor == trustedExecutor;
   }
 
   /* ============ Internal Functions ============ */
@@ -62,8 +54,8 @@ abstract contract ExecutorAware {
    */
   function _setTrustedExecutor(address _executor) internal {
     if (address(0) == _executor) revert ExecutorZeroAddress();
-    emit SetTrustedExecutor(_trustedExecutor, _executor);
-    _trustedExecutor = _executor;
+    emit SetTrustedExecutor(trustedExecutor, _executor);
+    trustedExecutor = _executor;
   }
 
 }

--- a/src/libraries/ExecutorParserLib.sol
+++ b/src/libraries/ExecutorParserLib.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+/**
+ * @title ExecutorParserLib
+ * @notice Library to parse additional data from Executor messages.
+ */
+library ExecutorParserLib {
+
+  /// @notice Parses the message ID from `msg.data`.
+  /// @return _messageId The bytes32 message ID uniquely identifying the message that was executed
+  function messageId() internal pure returns (bytes32 _messageId) {
+    if (msg.data.length >= 84) {
+      assembly {
+        _messageId := calldataload(sub(calldatasize(), 84))
+      }
+    }
+  }
+
+  /// @notice Parses the from chain ID from `msg.data`.
+  /// @return _fromChainId ID of the chain that dispatched the messages
+  function fromChainId() internal pure returns (uint256 _fromChainId) {
+    if (msg.data.length >= 52) {
+      assembly {
+        _fromChainId := calldataload(sub(calldatasize(), 52))
+      }
+    }
+  }
+
+  /// @notice Parses the sender address from `msg.data`.
+  /// @return _sender The payable sender address
+  function msgSender() internal pure returns (address payable _sender) {
+    if (msg.data.length >= 20) {
+      assembly {
+        _sender := shr(96, calldataload(sub(calldatasize(), 20)))
+      }
+    }
+  }
+
+}

--- a/src/libraries/ExecutorParserLib.sol
+++ b/src/libraries/ExecutorParserLib.sol
@@ -8,33 +8,39 @@ pragma solidity ^0.8.19;
 library ExecutorParserLib {
 
   /// @notice Parses the message ID from `msg.data`.
-  /// @return _messageId The bytes32 message ID uniquely identifying the message that was executed
-  function messageId() internal pure returns (bytes32 _messageId) {
+  /// @return The bytes32 message ID uniquely identifying the message that was executed
+  function messageId() internal pure returns (bytes32) {
+    bytes32 _messageId;
     if (msg.data.length >= 84) {
       assembly {
         _messageId := calldataload(sub(calldatasize(), 84))
       }
     }
+    return _messageId;
   }
 
   /// @notice Parses the from chain ID from `msg.data`.
-  /// @return _fromChainId ID of the chain that dispatched the messages
-  function fromChainId() internal pure returns (uint256 _fromChainId) {
+  /// @return ID of the chain that dispatched the messages
+  function fromChainId() internal pure returns (uint256) {
+    uint256 _fromChainId;
     if (msg.data.length >= 52) {
       assembly {
         _fromChainId := calldataload(sub(calldatasize(), 52))
       }
     }
+    return _fromChainId;
   }
 
   /// @notice Parses the sender address from `msg.data`.
-  /// @return _sender The payable sender address
-  function msgSender() internal pure returns (address payable _sender) {
+  /// @return The payable sender address
+  function msgSender() internal pure returns (address payable) {
+    address payable _sender;
     if (msg.data.length >= 20) {
       assembly {
         _sender := shr(96, calldataload(sub(calldatasize(), 20)))
       }
     }
+    return _sender;
   }
 
 }

--- a/test/abstract/ExecutorAware.t.sol
+++ b/test/abstract/ExecutorAware.t.sol
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import "forge-std/Test.sol";
+
+import { ExecutorZeroAddress } from "../../src/abstract/ExecutorAware.sol";
+import { ExecutorAwareHarness } from "../harness/ExecutorAwareHarness.sol";
+
+contract ExecutorAwareTest is Test {
+
+  /* ============ Events ============ */
+
+  event SetTrustedExecutor(address indexed previousExecutor, address indexed newExecutor);
+
+  /* ============ Vars ============ */
+
+  ExecutorAwareHarness target;
+
+  address executor;
+  address executor2;
+
+  /* ============ Set Up ============ */
+
+  function setUp() public {
+    executor = makeAddr("executor");
+    executor2 = makeAddr("executor2");
+
+    target = new ExecutorAwareHarness(executor);
+  }
+
+  /* ============ Constructor ============ */
+
+  function testConstructor_ExecutorZeroAddress() public {
+    vm.expectRevert(abi.encodeWithSelector(ExecutorZeroAddress.selector));
+    new ExecutorAwareHarness(address(0));
+  }
+
+  /* ============ Executor ============ */
+
+  function testIsTrustedExecutor() public {
+    assertEq(target.isTrustedExecutor(address(this)), false);
+    assertEq(target.isTrustedExecutor(address(0)), false);
+    assertEq(target.isTrustedExecutor(executor2), false);
+    assertEq(target.isTrustedExecutor(executor), true);
+  }
+
+  function testTrustedExecutor() public {
+    assertEq(target.trustedExecutor(), executor);
+  }
+
+  function testSetTrustedExecutor_Success() public {
+    assertEq(target.isTrustedExecutor(executor2), false);
+    vm.expectEmit();
+    emit SetTrustedExecutor(executor, executor2);
+    target.setTrustedExecutor(executor2);
+    assertEq(target.isTrustedExecutor(executor2), true);
+  }
+
+  function testSetTrustedExecutor_ExecutorZeroAddress() public {
+    vm.expectRevert(abi.encodeWithSelector(ExecutorZeroAddress.selector));
+    target.setTrustedExecutor(address(0));
+  }
+
+}

--- a/test/harness/ExecutorAwareHarness.sol
+++ b/test/harness/ExecutorAwareHarness.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import { ExecutorAware } from "../../src/abstract/ExecutorAware.sol";
+
+contract ExecutorAwareHarness is ExecutorAware {
+  
+  constructor(address _executor) ExecutorAware(_executor) { }
+
+  function setTrustedExecutor(address _executor) external {
+    _setTrustedExecutor(_executor);
+  }
+
+}

--- a/test/libraries/ExecutorParserLib.t.sol
+++ b/test/libraries/ExecutorParserLib.t.sol
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import "forge-std/Test.sol";
+
+import { ExecutorParserLibWrapper } from "../wrappers/ExecutorParserLibWrapper.sol";
+
+contract ExecutorParserLibTest is Test {
+
+  /* ============ Vars ============ */
+
+  ExecutorParserLibWrapper parser;
+
+  bytes data;
+  bytes executeData;
+
+  /* ============ Set Up ============ */
+
+  function setUp() public {
+    parser = new ExecutorParserLibWrapper();
+    data = data = abi.encode(address(this), uint256(1), bytes32(uint256(2)));
+  }
+
+  /* ============ messageId ============ */
+
+  function testMessageId() public {
+    executeData = abi.encodePacked(abi.encodeWithSelector(parser.messageId.selector), bytes32(uint256(2)), uint256(1), address(this));
+    (bool success, bytes memory result) = address(parser).call(executeData);
+    assertTrue(success);
+    assertEq(abi.decode(result, (bytes32)), bytes32(uint256(2)));
+  }
+
+  function testMessageId_CalldataTooShortReturnsZero() public {
+    executeData = abi.encodePacked(abi.encodeWithSelector(parser.messageId.selector), bytes32(uint256(2)), uint256(1));
+    (bool success, bytes memory result) = address(parser).call(executeData);
+    assertTrue(success);
+    assertEq(abi.decode(result, (bytes32)), bytes32(uint256(0))); // zero
+  }
+
+  /* ============ fromChainId ============ */
+
+  function testFromChainId() public {
+    executeData = abi.encodePacked(abi.encodeWithSelector(parser.fromChainId.selector), bytes32(uint256(2)), uint256(1), address(this));
+    (bool success, bytes memory result) = address(parser).call(executeData);
+    assertTrue(success);
+    assertEq(abi.decode(result, (uint256)), uint256(1));
+  }
+
+  function testFromChainId_CalldataTooShortReturnsZero() public {
+    executeData = abi.encodePacked(abi.encodeWithSelector(parser.fromChainId.selector), uint256(1));
+    (bool success, bytes memory result) = address(parser).call(executeData);
+    assertTrue(success);
+    assertEq(abi.decode(result, (uint256)), uint256(0)); // zero
+  }
+
+  /* ============ msgSender ============ */
+
+  function testMsgSender() public {
+    executeData = abi.encodePacked(abi.encodeWithSelector(parser.msgSender.selector), bytes32(uint256(2)), uint256(1), address(this));
+    (bool success, bytes memory result) = address(parser).call(executeData);
+    assertTrue(success);
+    assertEq(abi.decode(result, (address)), address(this));
+  }
+
+  function testMsgSender_CalldataTooShortReturnsZero() public {
+    executeData = abi.encodePacked(abi.encodeWithSelector(parser.msgSender.selector));
+    (bool success, bytes memory result) = address(parser).call(executeData);
+    assertTrue(success);
+    assertEq(abi.decode(result, (address)), address(0));
+  }
+
+}

--- a/test/wrappers/ExecutorParserLibWrapper.sol
+++ b/test/wrappers/ExecutorParserLibWrapper.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import { ExecutorParserLib } from "../../src/libraries/ExecutorParserLib.sol";
+
+contract ExecutorParserLibWrapper {
+
+  function messageId() public pure returns (bytes32 _messageId) {
+    _messageId = ExecutorParserLib.messageId();
+  }
+
+  function fromChainId() public pure returns (uint256 _fromChainId) {
+    _fromChainId = ExecutorParserLib.fromChainId();
+  }
+
+  function msgSender() public pure returns (address payable _sender) {
+    _sender = ExecutorParserLib.msgSender();
+  }
+
+}


### PR DESCRIPTION
### Summary
These changes support the changing of the trusted executor so a parent contract can update it internally with their own safety measures in place.

Additionally, low-level calls to parse executor message data (`_msgSender`, `_messageId`, `_fromChainId`) have been moved to a separate library and isolated from the `ExecutorAware` logic.

Note: `_msgSender` check for `isTrustedExecutor` has been removed since that check is implementation-specific. Any function that wants to check if they can trust any parsed data must first verify that `msg.sender` is a trusted executor.